### PR TITLE
Fix for php 8.2 Creation of dynamic property Error

### DIFF
--- a/admin/about.php
+++ b/admin/about.php
@@ -12,12 +12,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.4
  */
 class WPEX_Theme_Admin_About {
-
+	
 	/**
 	 * Get things started
 	 *
 	 * @since 1.0
 	 */
+	public $info;
+	
 	public function __construct() {
 
 		// Vars


### PR DESCRIPTION
In PHP 8.2 and later, attempting to create dynamic properties on objects directly like this:

$obj->newProperty = ‘value’;

Here is an Error exception:

Uncaught Error: Creation of dynamic property App\MyClass::$newProperty is not allowed

This change was introduced as a security and performance enhancement in PHP 8.2. However, it can break plugins that rely on dynamic property creation.

To fix just need  declare it as a class property first:
```
class WPEX_Theme_Admin_About {
	
	/**
	 * Get things started
	 *
	 * @since 1.0
	 */
	public $info;
```
fix for https://github.com/wpexplorer/wpex-blogger/issues/9 